### PR TITLE
Add basketball swipe scoring with 2pt/3pt targets and team swap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,21 +1,85 @@
-# Scoreboard App Development Guide
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+Scoreboard is an iOS app for tracking scores in two-team games (hockey, basketball, soccer, table tennis). It features customizable team colors, tap/swipe gestures for scoring, and iCloud sync via CloudKit.
 
 ## Build & Run Commands
-- Build and run: Open Xcode project and use Cmd+R
-- Clean build: Cmd+Shift+K in Xcode
-- Build only: Cmd+B in Xcode
-- Running tests: Cmd+U in Xcode
-- Run specific test: Select test method and press Ctrl+Alt+Cmd+U
+- **Open project**: `open "Scoreboard ∞.xcodeproj"`
+- **Build and run**: Cmd+R in Xcode
+- **Clean build**: Cmd+Shift+K in Xcode
+- **Build only**: Cmd+B in Xcode
+- **Run all tests**: Cmd+U in Xcode
+- **Run specific test**: Select test method and press Ctrl+Alt+Cmd+U
+
+## Architecture
+
+### Orientation-Based Navigation
+The app switches views based on device orientation (ContentView.swift:8-16):
+- **Portrait**: ConfigureView (team setup, saved teams, game type selection)
+- **Landscape**: ScoreboardView (active scoreboard display)
+
+### State Management
+- **AppConfiguration**: Root `ObservableObject` managing global state, injected via `@EnvironmentObject`
+  - Manages `homeTeam` and `awayTeam` (TeamConfiguration instances)
+  - Manages `savedTeams` array and `currentGameType`
+  - Auto-saves configuration changes to UserDefaults
+  - Coordinates iCloud sync via CloudKitManager
+
+- **TeamConfiguration**: `ObservableObject` representing a team's properties
+  - Properties: teamName, primaryColor, secondaryColor, fontColor, score
+  - Tracks `savedTeamId` to link with SavedTeam records
+  - Tracks `lastSavedState` for detecting unsaved changes
+
+### CloudKit Integration
+- **CloudKitManager**: Singleton managing iCloud persistence
+  - Stores teams in private CloudKit database as single "userTeams" record
+  - Teams encoded as JSON blob in CKRecord "teamsData" field
+  - Uses CKQuerySubscription for remote change notifications
+  - Merge strategy: cloud changes merged with local teams, cloud version wins on conflicts
+
+- **Remote Notifications**: AppDelegate handles CloudKit push notifications
+  - Triggers `teamsDidChangePublisher` (Combine PassthroughSubject)
+  - AppConfiguration subscribes to reload teams when remote changes occur
+
+### Data Models
+- **SavedTeam**: Identifiable, Codable struct for persisted teams
+  - UUID-based identity for deduplication across devices
+  - Includes gameType to filter teams by sport
+  - Converts to TeamConfiguration for active use
+
+- **CodableColor**: Wrapper for SwiftUI Color with Codable conformance
+  - Stores RGBA components as Doubles
+  - Required because SwiftUI Color is not Codable
+
+- **GameType**: Enum defining supported sports (hockey, basketball, soccer, tableTennis)
+
+### Persistence Strategy
+1. **UserDefaults**: Primary local storage (AppConfiguration.swift:135-158)
+   - Current game configuration saved automatically on any team property change
+   - Saved teams array cached locally as fallback
+
+2. **CloudKit**: Secondary cloud storage (AppConfiguration.swift:229-238)
+   - Teams synced when iCloudAvailable is true
+   - Graceful degradation: failures fall back to UserDefaults
+   - Merge strategy preserves local-only teams during sync
 
 ## Code Style Guidelines
-- **Naming**: Use camelCase for variables/functions, PascalCase for types/protocols
+- **Naming**: camelCase for variables/functions, PascalCase for types/protocols
 - **Views**: Suffix with "View" (e.g., ScoreboardView)
 - **Components**: Suffix with "Component" for reusable views
-- **Models**: Use plain structs that conform to Codable when persistence needed
-- **Error Handling**: Use enums with LocalizedError, Result type for async operations
-- **State Management**: Prefer @State, @Binding, @EnvironmentObject for view state
+- **Models**: Plain structs conforming to Codable for persistence
+- **Error Handling**: Enums with LocalizedError, Result type for async operations
+- **State Management**: @State, @Binding, @EnvironmentObject for view state
 - **Formatting**: 4-space indentation, no trailing whitespace
-- **Architecture**: Follow MVVM pattern with SwiftUI views
+- **Architecture**: MVVM pattern with SwiftUI views
 - **Extensions**: Prefer extensions for adding functionality to existing types
 - **Color Handling**: Use CodableColor for persistence of SwiftUI Color
 - **Comments**: Document public APIs and complex logic
+
+## Key Patterns
+- **Reactive auto-save**: Combine publishers trigger saves when team properties change (AppConfiguration.swift:125-133)
+- **iCloud availability check**: App checks CloudKit availability at launch and enables sync conditionally
+- **Team identity tracking**: TeamConfiguration.savedTeamId links active teams to SavedTeam records for update detection
+- **Saved state comparison**: TeamSavedState snapshot detects unsaved changes in UI

--- a/scoreboard/AppConfiguration.swift
+++ b/scoreboard/AppConfiguration.swift
@@ -247,4 +247,10 @@ final class AppConfiguration: ObservableObject {
         homeTeam.score = 0
         awayTeam.score = 0
     }
+
+    func swapTeams() {
+        let temp = homeTeam
+        homeTeam = awayTeam
+        awayTeam = temp
+    }
 }

--- a/scoreboard/ConfigureView.swift
+++ b/scoreboard/ConfigureView.swift
@@ -36,6 +36,24 @@ struct ConfigureView: View {
             // Two team configuration components stacked vertically
             VStack(spacing: 16) {
                 ConfigureTeamComponent(team: appConfig.homeTeam, isHomeTeam: true)
+
+                // Swap teams button
+                Button(action: {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                        appConfig.swapTeams()
+                    }
+                }) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "arrow.up.arrow.down")
+                            .font(.headline)
+                        Text("Swap Sides")
+                            .font(.subheadline)
+                    }
+                    .foregroundColor(.blue)
+                    .padding(.vertical, 4)
+                }
+                .buttonStyle(BorderlessButtonStyle())
+
                 ConfigureTeamComponent(team: appConfig.awayTeam, isHomeTeam: false)
             }
             .padding(.top, 10)

--- a/scoreboard/ScoreView.swift
+++ b/scoreboard/ScoreView.swift
@@ -1,63 +1,317 @@
 import SwiftUI
 
+// Basketball scoring state
+enum BasketballScoringState: Equatable {
+    case inactive
+    case waitingForTarget
+    case targetHit
+}
+
+// Target type for basketball scoring
+enum TargetType {
+    case twoPoint
+    case threePoint
+}
+
 struct ScoreView: View {
+    @EnvironmentObject var appConfig: AppConfiguration
     @ObservedObject var team: TeamConfiguration
+    let side: ScoreSide
+
     @State private var dragOffset: CGFloat = 0
     @State private var swipeCompleted: Bool = false
     @State private var flashColor: Color? = nil
     private let swipeThreshold: CGFloat = 123
 
+    // Basketball-specific state
+    @State private var basketballState: BasketballScoringState = .inactive
+    @State private var showTargets: Bool = false
+    @State private var twoPointHit: Bool = false
+    @State private var threePointHit: Bool = false
+    @State private var currentGestureLocation: CGPoint = .zero
+    @State private var initialPointScored: Bool = false
+    @State private var targetPulse: CGFloat = 1.0
+
     var body: some View {
-        ZStack {
-            (flashColor ?? team.primaryColor)
-                .animation(.easeOut(duration: 0.07), value: flashColor)
+        GeometryReader { geometry in
+            ZStack {
+                (flashColor ?? team.primaryColor)
+                    .animation(.easeOut(duration: 0.07), value: flashColor)
 
-            OutlinedText(
-                text: "\(team.score)",
-                fontName: "JerseyM54",
-                fontSize: 175,
-                textColor: UIColor(team.fontColor),  // Now uses user-selected font color
-                strokeColor: UIColor(team.secondaryColor),
-                strokeWidth: -5.0,
-                textAlignment: .center,
-                kern: 2.0
-            )
-            .padding(10)
-            .offset(y: dragOffset)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onTapGesture {
-            increaseScore()
-        }
-        .simultaneousGesture(
-            DragGesture()
-                .onChanged { value in
-                    guard !swipeCompleted else { return }
+                OutlinedText(
+                    text: "\(team.score)",
+                    fontName: "JerseyM54",
+                    fontSize: 175,
+                    textColor: UIColor(team.fontColor),
+                    strokeColor: UIColor(team.secondaryColor),
+                    strokeWidth: -5.0,
+                    textAlignment: .center,
+                    kern: 2.0
+                )
+                .padding(10)
+                .offset(y: dragOffset)
 
-                    if abs(value.translation.width) < 70 {
-                        dragOffset = value.translation.height * 0.33
-
-                        if value.translation.height < -swipeThreshold {
-                            increaseScore()
-                            swipeCompleted = true
-                            resetDrag()
-                        } else if value.translation.height > swipeThreshold {
-                            if team.score > 0 {
-                                decreaseScore()
-                            } else {
-                                showInvalidActionFeedback()
-                            }
-                            swipeCompleted = true
-                            resetDrag()
-                        }
+                // Basketball targets overlay
+                if isBasketballMode && showTargets {
+                    basketballTargetsOverlay(in: geometry.size)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .onTapGesture {
+                increaseScore(by: 1)
+            }
+            .simultaneousGesture(
+                DragGesture()
+                    .onChanged { value in
+                        handleDragChanged(value, in: geometry)
                     }
+                    .onEnded { _ in
+                        handleDragEnded()
+                    }
+            )
+        }
+    }
+
+    // MARK: - Basketball Mode Check
+
+    private var isBasketballMode: Bool {
+        appConfig.currentGameType == .basketball
+    }
+
+    // MARK: - Gesture Handling
+
+    private func handleDragChanged(_ value: DragGesture.Value, in geometry: GeometryProxy) {
+        guard !swipeCompleted else { return }
+
+        // Track gesture location
+        currentGestureLocation = value.location
+
+        if isBasketballMode {
+            handleBasketballDrag(value, in: geometry)
+        } else {
+            handleStandardDrag(value)
+        }
+    }
+
+    private func handleStandardDrag(_ value: DragGesture.Value) {
+        if abs(value.translation.width) < 70 {
+            dragOffset = value.translation.height * 0.33
+
+            if value.translation.height < -swipeThreshold {
+                increaseScore(by: 1)
+                swipeCompleted = true
+                resetDrag()
+            } else if value.translation.height > swipeThreshold {
+                if team.score > 0 {
+                    decreaseScore()
+                } else {
+                    showInvalidActionFeedback()
                 }
-                .onEnded { _ in
-                    swipeCompleted = false
-                    resetDrag()
+                swipeCompleted = true
+                resetDrag()
+            }
+        }
+    }
+
+    private func handleBasketballDrag(_ value: DragGesture.Value, in geometry: GeometryProxy) {
+        // More lenient horizontal restriction for basketball to allow hitting corner 3-point target
+        if abs(value.translation.width) < 200 {
+            dragOffset = value.translation.height * 0.33
+
+            // Check if we've crossed the initial threshold (swipe up started)
+            if value.translation.height < -30 && !showTargets && basketballState == .inactive {
+                showTargets = true
+                basketballState = .waitingForTarget
+                startTargetPulseAnimation()
+            }
+
+            // Check if initial threshold crossed for first point (only once!)
+            if value.translation.height < -swipeThreshold && basketballState == .waitingForTarget && !initialPointScored {
+                increaseScore(by: 1, hapticCount: 1)
+                initialPointScored = true
+                // Keep targets visible for continued gesture
+            }
+
+            // Check for target hits while dragging
+            if basketballState == .waitingForTarget && showTargets {
+                checkTargetHits(at: value.location, in: geometry.size)
+            }
+
+            // Handle swipe down
+            if value.translation.height > swipeThreshold && basketballState == .inactive {
+                if team.score > 0 {
+                    decreaseScore()
+                } else {
+                    showInvalidActionFeedback()
                 }
+                swipeCompleted = true
+                resetDrag()
+            }
+        }
+    }
+
+    private func handleDragEnded() {
+        swipeCompleted = false
+        resetDrag()
+
+        // Fade out targets with 200ms animation
+        if showTargets {
+            withAnimation(.easeOut(duration: 0.2)) {
+                showTargets = false
+            }
+        }
+
+        // Reset basketball state
+        basketballState = .inactive
+        twoPointHit = false
+        threePointHit = false
+        initialPointScored = false
+        targetPulse = 1.0
+    }
+
+    // MARK: - Basketball Target Rendering
+
+    @ViewBuilder
+    private func basketballTargetsOverlay(in size: CGSize) -> some View {
+        ZStack {
+            // 2-Point Target (center top)
+            basketballTarget(
+                points: 2,
+                position: twoPointPosition(in: size),
+                color: .white,
+                accentColor: .orange,
+                isHit: twoPointHit
+            )
+
+            // 3-Point Target (corner based on side)
+            basketballTarget(
+                points: 3,
+                position: threePointPosition(in: size),
+                color: .white,
+                accentColor: .green,
+                isHit: threePointHit
+            )
+        }
+        .transition(.opacity)
+    }
+
+    @ViewBuilder
+    private func basketballTarget(points: Int, position: CGPoint, color: Color, accentColor: Color, isHit: Bool) -> some View {
+        ZStack {
+            // Outer glow ring
+            Circle()
+                .fill(
+                    RadialGradient(
+                        gradient: Gradient(colors: [accentColor.opacity(0.5), accentColor.opacity(0.0)]),
+                        center: .center,
+                        startRadius: 20,
+                        endRadius: 50
+                    )
+                )
+                .frame(width: 100, height: 100)
+
+            // Main target circle with gradient
+            Circle()
+                .fill(
+                    RadialGradient(
+                        gradient: Gradient(colors: [color.opacity(0.9), color.opacity(0.6)]),
+                        center: .center,
+                        startRadius: 5,
+                        endRadius: 35
+                    )
+                )
+                .frame(width: 70, height: 70)
+                .overlay(
+                    Circle()
+                        .stroke(accentColor, lineWidth: 4)
+                )
+                .shadow(color: accentColor.opacity(0.7), radius: isHit ? 25 : 12, x: 0, y: 0)
+
+            // Points text with glow
+            Text("\(points)")
+                .font(.system(size: 40, weight: .black))
+                .foregroundColor(accentColor)
+                .shadow(color: accentColor, radius: 8, x: 0, y: 0)
+        }
+        .scaleEffect(isHit ? 1.5 : targetPulse)
+        .animation(.spring(response: 0.3, dampingFraction: 0.6), value: isHit)
+        .position(position)
+    }
+
+    private func startTargetPulseAnimation() {
+        withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
+            targetPulse = 1.1
+        }
+    }
+
+    // MARK: - Target Positioning
+
+    private func twoPointPosition(in size: CGSize) -> CGPoint {
+        CGPoint(
+            x: size.width / 2,
+            y: size.height * 0.2  // 20% from top
         )
     }
+
+    private func threePointPosition(in size: CGSize) -> CGPoint {
+        switch side {
+        case .left:
+            // Top-left corner
+            return CGPoint(
+                x: size.width * 0.15,
+                y: size.height * 0.15
+            )
+        case .right:
+            // Top-right corner
+            return CGPoint(
+                x: size.width * 0.85,
+                y: size.height * 0.15
+            )
+        }
+    }
+
+    // MARK: - Hit Detection
+
+    private func checkTargetHits(at location: CGPoint, in size: CGSize) {
+        let hitRadius: CGFloat = 50
+
+        // Check 2-point target
+        if !twoPointHit && !threePointHit {
+            let twoPointPos = twoPointPosition(in: size)
+            let distance2pt = sqrt(pow(location.x - twoPointPos.x, 2) + pow(location.y - twoPointPos.y, 2))
+
+            if distance2pt <= hitRadius {
+                handleTargetHit(.twoPoint)
+                return
+            }
+
+            // Check 3-point target
+            let threePointPos = threePointPosition(in: size)
+            let distance3pt = sqrt(pow(location.x - threePointPos.x, 2) + pow(location.y - threePointPos.y, 2))
+
+            if distance3pt <= hitRadius {
+                handleTargetHit(.threePoint)
+                return
+            }
+        }
+    }
+
+    private func handleTargetHit(_ targetType: TargetType) {
+        basketballState = .targetHit
+
+        switch targetType {
+        case .twoPoint:
+            twoPointHit = true
+            increaseScore(by: 1, hapticCount: 2)  // +1 more point (total +2)
+        case .threePoint:
+            threePointHit = true
+            increaseScore(by: 2, hapticCount: 3)  // +2 more points (total +3)
+        }
+
+        swipeCompleted = true
+    }
+
+    // MARK: - Drag Reset
 
     private func resetDrag() {
         withAnimation(.spring()) {
@@ -65,9 +319,11 @@ struct ScoreView: View {
         }
     }
 
-    private func increaseScore() {
-        team.score += 1
-        triggerHapticFeedback()
+    // MARK: - Score Management
+
+    private func increaseScore(by points: Int, hapticCount: Int = 1) {
+        team.score += points
+        triggerMultipleHaptics(count: hapticCount)
         triggerFlash()
     }
 
@@ -79,15 +335,30 @@ struct ScoreView: View {
         }
     }
 
+    // MARK: - Haptic Feedback
+
     private func triggerHapticFeedback() {
         let generator = UIImpactFeedbackGenerator(style: .heavy)
         generator.impactOccurred()
+    }
+
+    private func triggerMultipleHaptics(count: Int) {
+        let generator = UIImpactFeedbackGenerator(style: .heavy)
+        generator.prepare()
+
+        for i in 0..<count {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Double(i) * 0.08) {
+                generator.impactOccurred(intensity: 1.0)
+            }
+        }
     }
 
     private func showInvalidActionFeedback() {
         let generator = UINotificationFeedbackGenerator()
         generator.notificationOccurred(.error)
     }
+
+    // MARK: - Visual Feedback
 
     private func triggerFlash() {
         flashColor = team.secondaryColor.opacity(0.4)
@@ -99,7 +370,11 @@ struct ScoreView: View {
 
 struct ScoreView_Previews: PreviewProvider {
     static var previews: some View {
-        ScoreView(team: TeamConfiguration(teamName: "Test", primaryColor: .red, secondaryColor: .blue, fontColor: .white))
-            .previewLayout(.sizeThatFits)
+        ScoreView(
+            team: TeamConfiguration(teamName: "Test", primaryColor: .red, secondaryColor: .blue, fontColor: .white),
+            side: .left
+        )
+        .environmentObject(AppConfiguration())
+        .previewLayout(.sizeThatFits)
     }
 }

--- a/scoreboard/ScoreboardView.swift
+++ b/scoreboard/ScoreboardView.swift
@@ -1,12 +1,17 @@
 import SwiftUI
 
+enum ScoreSide {
+    case left
+    case right
+}
+
 struct ScoreboardView: View {
     @EnvironmentObject var appConfig: AppConfiguration
 
     var body: some View {
         HStack(spacing: 0) {
-            ScoreView(team: appConfig.homeTeam) // Home Team
-            ScoreView(team: appConfig.awayTeam) // Away Team
+            ScoreView(team: appConfig.homeTeam, side: .left) // Home Team
+            ScoreView(team: appConfig.awayTeam, side: .right) // Away Team
         }
         .ignoresSafeArea()
     }


### PR DESCRIPTION
## Summary
- **Basketball Swipe Scoring**: Interactive 2-point and 3-point targets appear during upward swipes in Basketball mode
- **Visual Feedback**: Pulsing targets with radial gradients, dynamic shadows, and scale animations on hit
- **Multi-Haptic Patterns**: Single, double, or triple haptic feedback based on points scored
- **Team Swap Feature**: Added button to swap team sides in configuration screen
- **Updated Documentation**: Comprehensive CLAUDE.md with architecture details

## Basketball Scoring Flow
1. User swipes up → targets appear at -30px threshold
2. At -123px threshold → +1 point scored with single haptic
3. Continue gesture to hit targets:
   - **2-Point (Orange)**: Center-top position, total +2 points, double haptic
   - **3-Point (Green)**: Corner position (left/right aware), total +3 points, triple haptic
4. Targets fade out with 200ms animation when gesture ends

## Technical Details
- Added `ScoreSide` enum for left/right positioning awareness
- Basketball state machine prevents multiple scoring from same gesture
- Increased horizontal gesture tolerance (70px → 200px) for diagonal swipes to 3pt target
- Targets use radial gradients, outer glow rings, and pulsing animation (1.0 → 1.1 scale)
- Only active when `currentGameType == .basketball`

## Team Management
- Swap sides button in ConfigureView with spring animation
- New `swapTeams()` function in AppConfiguration

## Files Changed
- `ScoreboardView.swift` - Added ScoreSide enum and passing to ScoreView
- `ScoreView.swift` - Basketball scoring system with targets and hit detection
- `AppConfiguration.swift` - Added swapTeams() function
- `ConfigureView.swift` - Added swap button UI
- `CLAUDE.md` - Comprehensive architecture documentation
- `.gitignore` - Added for project housekeeping

## Test Plan
- [x] Build succeeds with no errors
- [ ] Test 1-point scoring (quick swipe up)
- [ ] Test 2-point scoring (swipe to orange target)
- [ ] Test 3-point scoring (swipe to green corner target)
- [ ] Verify targets only appear in Basketball mode
- [ ] Test swap sides button functionality
- [ ] Verify haptic feedback patterns (1x, 2x, 3x)
- [ ] Test on both left and right sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)