### PR TITLE
Add Xcode Cloud automatic versioning from git tags

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+echo "Running Xcode Cloud post-clone script"
+
+if [ -n "$CI_TAG" ]; then
+  # Get the tag name from environment (set by Xcode Cloud)
+  TAG_NAME="${CI_TAG}"
+
+  # Strip off the leading "v" from the tag name
+  TAG_NAME=${TAG_NAME#v}
+
+  # Define the path to Info.plist file
+  PLIST_PATH="${CI_PRIMARY_REPOSITORY_PATH}/scoreboard/Info.plist"
+
+  echo "Setting version from tag: $TAG_NAME"
+
+  # Update CFBundleShortVersionString (user-facing version)
+  /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $TAG_NAME" "$PLIST_PATH"
+
+  # Update CFBundleVersion (build number) with Xcode Cloud build number
+  /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $CI_BUILD_NUMBER" "$PLIST_PATH"
+
+  echo "✓ Updated Info.plist:"
+  echo "  Version: $TAG_NAME"
+  echo "  Build: $CI_BUILD_NUMBER"
+else
+  echo "No CI_TAG found, skipping version update"
+fi


### PR DESCRIPTION
## Summary
Automates app version management using git tags with Xcode Cloud's `ci_post_clone.sh` script.

## How It Works
When Xcode Cloud builds a tagged commit:
1. Reads `CI_TAG` environment variable (e.g., "v1.2.0")
2. Strips "v" prefix → "1.2.0"
3. Updates `CFBundleShortVersionString` to "1.2.0"
4. Updates `CFBundleVersion` to Xcode Cloud's build number

## Simplified Workflow
**Before:**
1. Merge PR
2. Open Xcode
3. Manually update version
4. Commit version change
5. Tag and push

**After:**
1. Merge PR
2. `git tag v1.2.0 && git push origin v1.2.0`

That's it! Xcode Cloud handles the rest.

## Benefits
- ✓ No manual version updates in Xcode
- ✓ Version always matches git tag
- ✓ Build number auto-managed by Xcode Cloud
- ✓ Cleaner git history (no version bump commits)
- ✓ Impossible to forget version updates

## Files Added
- `ci_scripts/ci_post_clone.sh` - Xcode Cloud post-clone script

## Testing
After merge, test by creating a tag:
```bash
git tag v1.2.0-test
git push origin v1.2.0-test
```
Verify Xcode Cloud build has version 1.2.0-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)