### PR TITLE
Fix ci_post_clone.sh to add version keys if they don't exist

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -17,10 +17,12 @@ if [ -n "$CI_TAG" ]; then
 
   echo "Setting version from tag: $TAG_NAME"
 
-  # Update CFBundleShortVersionString (user-facing version)
+  # Add or update CFBundleShortVersionString (user-facing version)
+  /usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string $TAG_NAME" "$PLIST_PATH" 2>/dev/null || \
   /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $TAG_NAME" "$PLIST_PATH"
 
-  # Update CFBundleVersion (build number) with Xcode Cloud build number
+  # Add or update CFBundleVersion (build number) with Xcode Cloud build number
+  /usr/libexec/PlistBuddy -c "Add :CFBundleVersion string $CI_BUILD_NUMBER" "$PLIST_PATH" 2>/dev/null || \
   /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $CI_BUILD_NUMBER" "$PLIST_PATH"
 
   echo "✓ Updated Info.plist:"


### PR DESCRIPTION
The Info.plist uses GENERATE_INFOPLIST_FILE so version keys don't exist by default. Script now adds keys first, then sets them if they already exist.

Uses: Add || Set pattern to handle both cases gracefully.